### PR TITLE
Fix vue install command to use cli package

### DIFF
--- a/renderer/constants.js
+++ b/renderer/constants.js
@@ -47,9 +47,9 @@ const appTypes = {
       run: 'run start'
     }
   },
-  nuxt: {
+  vue: {
     name: 'Vue App',
-    install: 'vue create -d',
+    install: '@vue/cli create -d',
     defaults: {
       type: 'create-vue-app',
       port: 8080,


### PR DESCRIPTION
The previous install command would fail to find "vue" as a package. Seems like the cli is behind the vue namespace.

Also changed property name from nuxt to vue.

Hope that helps :)